### PR TITLE
Better handling of deactivation/reactivation of links and events

### DIFF
--- a/xpi/chrome/content/htmlWA.js
+++ b/xpi/chrome/content/htmlWA.js
@@ -505,7 +505,7 @@ webannotator.htmlWA = {
                 for (var attr, j = 0 ; j < length; j++){
                     attr = attrs.item(j);
                     attrName = attr.nodeName.toLowerCase();
-                    if ((element.nodeName.toLowerCase() === "a" && attrName.toLowerCase() === "href") || (attrName.charAt(0) === 'o' && attrName.charAt(1) === 'n') || (attrName.charAt(0) === 'a' && attrName.charAt(1) === 'j'  && attrName.charAt(2) === 'a'  && attrName.charAt(3) === 'x' && attrName.charAt(4) === 'i' && attrName.charAt(5) === 'f' && attrName.charAt(6) === 'y')) {
+                    if ((element.nodeName.toLowerCase() === "a" && attrName.toLowerCase() === "href") || (attrName.startsWith("on")) || (attrName.startsWith("ajaxify"))) {
 						toRemove.push(attrName);
 						toPush[wa_prefix + attrName] = element.getAttribute(attrName);
                     }


### PR DESCRIPTION
Concerning issue #12, there was a bug when parsing element attributes, now corrected. All a.href, all on\* attributes and all ajaxify attributes are deactivated.

However there are plenty of other ways to trigger a page change when clicking on an element. 
For example in https://www.facebook.com/MadHatterCafeWeymouth, clicking on the address does not lead anywhere (OK), but clicking on the parent div (no text) leads me to another page. Didn't find why.
