### PR TITLE
fix links enabling

### DIFF
--- a/xpi/chrome/content/htmlWA.js
+++ b/xpi/chrome/content/htmlWA.js
@@ -510,11 +510,11 @@ webannotator.htmlWA = {
                         toPush[wa_prefix + attrName] = element.getAttribute(attrName);
                     }
                 }
-                for (var elem in toRemove) {
-                    element.removeAttribute(toRemove[elem]);
+                for (var attrName in toRemove) {
+                    element.removeAttribute(toRemove[attrName]);
                 }
-                for (var elem in toPush) {
-                    element.setAttribute(elem, toPush[elem]);
+                for (var attrName in toPush) {
+                    element.setAttribute(attrName, toPush[attrName]);
                 }
             }
             _status = "disable";
@@ -527,21 +527,21 @@ webannotator.htmlWA = {
                 var element = links[i];
                 var attrs = element.attributes;
                 var attrName; var length = attrs.length;
-                for (var attr, j = 0 ; j < length; j++){
-                    var toRemove = [];
-                    var toPush = {};
-                    attr = attrs.item(j);
+                var toRemove = [];
+                var toPush = {};
+                for (var j = 0 ; j < length; j++){
+                    var attr = attrs.item(j);
                     attrName = attr.nodeName;
                     if (attrName.substring(0, wa_prefix.length).toLowerCase() === wa_prefix.toLowerCase()) {
                         toRemove.push(attrName);
                         toPush[attrName.substring(wa_prefix.length, attrName.length)] = element.getAttribute(attrName);
                    }
                 }
-                for (var elem in toRemove) {
-                    element.removeAttribute(toRemove[elem]);
+                for (var attrName in toRemove) {
+                    element.removeAttribute(toRemove[attrName]);
                 }
-                for (var elem in toPush) {
-                    element.setAttribute(elem, toPush[elem]);
+                for (var attrName in toPush) {
+                    element.setAttribute(attrName, toPush[attrName]);
                 }
 
 


### PR DESCRIPTION
In link enabling code `toRemove` and `toPush` objects were created inside a loop that iterates over attributes. They should be created in a level above, in a loop that iterates over elements. This caused two issues:

1) only last attribute was enabled (that was not a problem because usually there is only one such attribute);
2) toRemove and toPush objects were not cleaned for elements without attributes - this causes unrelated elements (e.g. a `<span>` tag inside `<a href="...">` tag) to get href attributes from the previous elements.
