### PR TITLE
Add an option for edit/delete popup delays. Use a shorter "show popup" delay (100) by default.

### DIFF
--- a/xpi/chrome/content/htmlWA.js
+++ b/xpi/chrome/content/htmlWA.js
@@ -93,6 +93,7 @@ webannotator.htmlWA = {
      */
     showEditAnnotationMenu: function (evt, id) {
         clearTimeout(webannotator.showEditEvent);
+        var showDelay = webannotator.prefs.getIntPref('editIconsShowDelay');
         webannotator.htmlWA.receiveWindowUnblinkAnnotation();
         webannotator.popups.hide_popup("webannotator-edit-menu");
         webannotator.showEditEvent = setTimeout(function() {
@@ -103,7 +104,7 @@ webannotator.htmlWA = {
                 webannotator.main.receiveSelectAnnotation(id);
                 webannotator.htmlWA.receiveWindowBlinkAnnotation(id);
             }
-        }, 500);
+        }, showDelay);
     },
 
     /**
@@ -120,7 +121,12 @@ webannotator.htmlWA = {
      */
     hideEditAnnotationMenu: function () {
         clearTimeout(webannotator.showEditEvent);
-        webannotator.showEditEvent = setTimeout(function() {webannotator.popups.hide_popup('webannotator-edit-menu'); webannotator.main.receiveShowAnnotations(); webannotator.htmlWA.receiveWindowUnblinkAnnotation();}, 500);
+        var hideDelay = webannotator.prefs.getIntPref('editIconsHideDelay');
+        webannotator.showEditEvent = setTimeout(function() {
+            webannotator.popups.hide_popup('webannotator-edit-menu');
+            webannotator.main.receiveShowAnnotations();
+            webannotator.htmlWA.receiveWindowUnblinkAnnotation();
+        }, hideDelay);
     },
 
     /**

--- a/xpi/chrome/locale/en/wa.dtd
+++ b/xpi/chrome/locale/en/wa.dtd
@@ -60,3 +60,7 @@
 
 &wa.saveformat_complete;: Save the whole web page along with pictures. This choice allows you to view it as originally shown (with pictures), but it may not keep the HTML link structure of the original page. &wa.name; creates a new directory where the page is saved to save pictures and other files necessary to show the whole web page.
 ">
+<!ENTITY wa.editicons_show_delay "Popup delay">
+<!ENTITY wa.editicons_show_delay_description "Delay (in ms) after which &quot;Edit&quot; and &quot;Delay&quot; icons appear when mouse is over an entity.">
+<!ENTITY wa.editicons_hide_delay "Popup hiding delay">
+<!ENTITY wa.editicons_hide_delay_description "Delay (in ms) after which &quot;Edit&quot; and &quot;Delay&quot; icons disappear when mouse moves out of an entity.">

--- a/xpi/chrome/locale/fr/wa.dtd
+++ b/xpi/chrome/locale/fr/wa.dtd
@@ -38,14 +38,14 @@
 <!ENTITY wa.showtitlepopup "Montrer le popup d'annotation du titre (balise &lt;title&gt;) dès l'activation">
 <!ENTITY wa.showtitlepopup_description "Si cette option est activée, le popup d'annotation du titre (balise &lt;title&gt;) sera affiché dès l'activation. Dans le cas contraire, il faudra cliquer sur l'icône associée pour montrer le titre et l'annoter">
 <!ENTITY wa.activate_links "Activer les liens à la sauvegarde">
-<!ENTITY wa.activate_links_description "&wa.name; désactive temporairement les liens de la page pendant l'annotation, et les liens sont réactivés pour la sauvegarde. 
+<!ENTITY wa.activate_links_description "&wa.name; désactive temporairement les liens de la page pendant l'annotation, et les liens sont réactivés pour la sauvegarde.
 Désactivez cette option pour ne pas réactiver les liens lors de la sauvegarde.">
 <!ENTITY wa.autoexport "Exportation automatique">
 <!ENTITY wa.autoexport_description "Crée automatiquement un fichier &lt;fichier&gt;.export.html en plus du fichier &lt;fichier&gt;.html de sauvegarde quand la commande '&wa.saveas;' est appelée.">
 <!ENTITY wa.naming "Stratégie de nommage">
 <!ENTITY wa.naming_usetitles "Utiliser les titres">
 <!ENTITY wa.naming_usenumbers "Utiliser des numéros">
-<!ENTITY wa.naming_description "&wa.naming_usetitles; : pour les nouveaux fichiers, le titre de la page est suggéré lors de la première sauvegarde. 
+<!ENTITY wa.naming_description "&wa.naming_usetitles; : pour les nouveaux fichiers, le titre de la page est suggéré lors de la première sauvegarde.
 
 &wa.naming_usenumbers;: des nombres auto-incrémentés sont suggérés comme nom de fichier lors de la première sauvegarde.">
 <!ENTITY wa.saveformat "Format de sauvegarde">
@@ -61,3 +61,7 @@ Désactivez cette option pour ne pas réactiver les liens lors de la sauvegarde.
 
 &wa.saveformat_complete; : sauvegarde l'intégrale de la page, avec les images et l'ensemble des ressources. Ce choix vous permet de visualiser la page par la suite sur votre navigateur, mais peut ne pas préserver la structure de la page HTML originale. &wa.name; crée un répertoire contenant l'ensemble des images et des ressources nécessaires pour la visualisation..
 ">
+<!ENTITY wa.editicons_show_delay "Popup delay">
+<!ENTITY wa.editicons_show_delay_description "Delay (in ms) after which &quot;Edit&quot; and &quot;Delay&quot; icons appear when mouse is over an entity.">
+<!ENTITY wa.editicons_hide_delay "Popup hiding delay">
+<!ENTITY wa.editicons_hide_delay_description "Delay (in ms) after which &quot;Edit&quot; and &quot;Delay&quot; icons disappear when mouse moves out of an entity.">

--- a/xpi/defaults/preferences/defaults.js
+++ b/xpi/defaults/preferences/defaults.js
@@ -5,3 +5,5 @@ pref("extensions.webannotator.quitAfterSave", true);
 pref("extensions.webannotator.autoExport", false);
 pref("extensions.webannotator.showTitlePopup", false);
 pref("extensions.webannotator.namingStrategy", "numbers");
+pref("extensions.webannotator.editIconsShowDelay", 100);
+pref("extensions.webannotator.editIconsHideDelay", 500);

--- a/xpi/options.xul
+++ b/xpi/options.xul
@@ -50,4 +50,12 @@
 &wa.saveformat_description;
 </setting>
 
+<setting pref="extensions.webannotator.editIconsShowDelay" type="integer" title="&wa.editicons_show_delay;">
+&wa.editicons_show_delay_description;
+</setting>
+
+<setting pref="extensions.webannotator.editIconsHideDelay" type="integer" title="&wa.editicons_hide_delay;">
+&wa.editicons_hide_delay_description;
+</setting>
+
 </vbox>


### PR DESCRIPTION
Hi, 

This could make the interface faster to work for users. I'd also increase "hide" delay to 1s by default. What do you think?
